### PR TITLE
flattenField() - include non-leaf fields

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -167,6 +167,17 @@ func flattenField(key []string, f Field) ([]Field, error) {
 		flat = append(flat, tmpFlats...)
 	}
 
+	// I would consider this to be an incorrect definition to
+	// have sub-fields in a field not declared as a type=group.
+	// This will include those fields in the list in order to not
+	// mask bad definitions.
+	if f.Type != "" && f.Type != "group" {
+		parent := f
+		parent.Name = strings.Join(parentName, ".")
+		parent.Fields = nil
+		flat = append(flat, parent)
+	}
+
 	return flat, nil
 }
 


### PR DESCRIPTION
Include fields that are not declared as type=group when they contain sub-fields.

Given `a` and `a.b` are both declared as keyword fields then flattenField() will now return them both. Previously the type of `a` would have been ignored because it was assumed that `a` must be a type=group. But sometimes this is not true (though it may be an invalid definition).