### PR TITLE
fields.go - Add YAML path to all fields

### DIFF
--- a/fields_test.go
+++ b/fields_test.go
@@ -18,6 +18,7 @@
 package fleetpkg
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -77,6 +78,10 @@ func TestReadFields(t *testing.T) {
 		}
 		if f.Column() == 0 {
 			t.Errorf("sourceColumn is empty")
+		}
+		fmt.Printf("%s:%d:%d %s - %s\n", f.Path(), f.Line(), f.Column(), f.Name, f.YAMLPath)
+		if f.YAMLPath == "" {
+			t.Errorf("YAMLPath is empty")
 		}
 	}
 }


### PR DESCRIPTION
Include the YAML path (e.g. `$[1].fields[2]`) to the field definition in fleetpkg.Field.