### PR TITLE
bump Go major version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: go.mod tidy
         run: go mod tidy && git diff --exit-code
@@ -29,8 +29,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.21.x
-          - 1.19.x
+          - 1.22.x
+          - 1.20.x
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andrewkroh/go-fleetpkg
 
-go 1.19
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
Use Go 1.22 on CI and require Go 1.20 for the module