### PR TITLE
Add new agentless params and discovery

### DIFF
--- a/fleetpkg.go
+++ b/fleetpkg.go
@@ -287,7 +287,10 @@ type DeploymentModes struct {
 
 	// Options specific to the Agentless deployment mode. This mode is used in offerings where the Elastic Agents running these policies are fully managed for the user.
 	Agentless struct {
-		Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+		Enabled      *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+		Organization string `json:"organization,omitempty" yaml:"organization,omitempty"` // The responsible organization of the integration. This is used to tag the agentless agent deployments for monitoring.
+		Division     string `json:"division,omitempty" yaml:"division,omitempty"`         // The division responsible for the integration. This is used to tag the agentless agent deployments for monitoring.
+		Team         string `json:"team,omitempty" yaml:"team,omitempty"`                 // The team responsible for the integration. This is used to tag the agentless agent deployments for monitoring.
 	} `json:"agentless,omitempty" yaml:"agentless,omitempty"`
 }
 

--- a/fleetpkg.go
+++ b/fleetpkg.go
@@ -122,6 +122,7 @@ type Manifest struct {
 	Elasticsearch   *ElasticsearchRequirements `json:"elasticsearch,omitempty" yaml:"elasticsearch,omitempty"`
 	Agent           *AgentRequirements         `json:"agent,omitempty" yaml:"agent,omitempty"`
 	DeploymentModes *DeploymentModes           `json:"deployment_modes,omitempty" yaml:"deployment_modes,omitempty"`
+	Discovery       *Discovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
 
 	sourceFile string
 }
@@ -129,6 +130,15 @@ type Manifest struct {
 // Path returns the path to the integration manifest.yml.
 func (m Manifest) Path() string {
 	return m.sourceFile
+}
+
+// Discovery provides a description of the data this package can be used with. It
+// can be used to discover the package from elements in the existing data.
+type Discovery struct {
+	// Description of the fields this package can be used with.
+	Fields []struct {
+		Name string `json:"name,omitempty" yaml:"name,omitempty"` // Name of the field.
+	} `json:"fields,omitempty" yaml:"fields,omitempty"`
 }
 
 type ElasticsearchRequirements struct {


### PR DESCRIPTION
- Add `discovery` to manifest.
- Add organization,division,team to deployment_modes.agentless. See package-spec 801.
