### PR TITLE
fleetpkg.go - add policy_templates_behavior to manifest

### DIFF
--- a/fleetpkg.go
+++ b/fleetpkg.go
@@ -103,26 +103,27 @@ func (f FieldsFile) Path() string {
 }
 
 type Manifest struct {
-	Name            string                     `json:"name,omitempty" yaml:"name,omitempty"`
-	Title           string                     `json:"title,omitempty" yaml:"title,omitempty"`
-	Version         string                     `json:"version,omitempty" yaml:"version,omitempty"`
-	Release         string                     `json:"release,omitempty" yaml:"release,omitempty"`
-	Description     string                     `json:"description,omitempty" yaml:"description,omitempty"`
-	Type            string                     `json:"type,omitempty" yaml:"type,omitempty"`
-	Icons           []Icons                    `json:"icons,omitempty" yaml:"icons,omitempty"`
-	FormatVersion   string                     `json:"format_version,omitempty" yaml:"format_version,omitempty"`
-	License         string                     `json:"license,omitempty" yaml:"license,omitempty"`
-	Categories      []string                   `json:"categories,omitempty" yaml:"categories,omitempty"`
-	Conditions      Conditions                 `json:"conditions,omitempty" yaml:"conditions,omitempty"`
-	Screenshots     []Screenshots              `json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
-	Source          Source                     `json:"source,omitempty" yaml:"source,omitempty"`
-	Vars            []Var                      `json:"vars,omitempty" yaml:"vars,omitempty"`
-	PolicyTemplates []PolicyTemplate           `json:"policy_templates,omitempty" yaml:"policy_templates,omitempty"`
-	Owner           Owner                      `json:"owner,omitempty" yaml:"owner,omitempty"`
-	Elasticsearch   *ElasticsearchRequirements `json:"elasticsearch,omitempty" yaml:"elasticsearch,omitempty"`
-	Agent           *AgentRequirements         `json:"agent,omitempty" yaml:"agent,omitempty"`
-	DeploymentModes *DeploymentModes           `json:"deployment_modes,omitempty" yaml:"deployment_modes,omitempty"`
-	Discovery       *Discovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	Name                    string                     `json:"name,omitempty" yaml:"name,omitempty"`
+	Title                   string                     `json:"title,omitempty" yaml:"title,omitempty"`
+	Version                 string                     `json:"version,omitempty" yaml:"version,omitempty"`
+	Release                 string                     `json:"release,omitempty" yaml:"release,omitempty"`
+	Description             string                     `json:"description,omitempty" yaml:"description,omitempty"`
+	Type                    string                     `json:"type,omitempty" yaml:"type,omitempty"`
+	Icons                   []Icons                    `json:"icons,omitempty" yaml:"icons,omitempty"`
+	FormatVersion           string                     `json:"format_version,omitempty" yaml:"format_version,omitempty"`
+	License                 string                     `json:"license,omitempty" yaml:"license,omitempty"`
+	Categories              []string                   `json:"categories,omitempty" yaml:"categories,omitempty"`
+	Conditions              Conditions                 `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	Screenshots             []Screenshots              `json:"screenshots,omitempty" yaml:"screenshots,omitempty"`
+	Source                  Source                     `json:"source,omitempty" yaml:"source,omitempty"`
+	Vars                    []Var                      `json:"vars,omitempty" yaml:"vars,omitempty"`
+	PolicyTemplates         []PolicyTemplate           `json:"policy_templates,omitempty" yaml:"policy_templates,omitempty"`
+	PolicyTemplatesBehavior string                     `json:"policy_templates_behavior,omitempty" yaml:"policy_templates_behavior,omitempty"` // Expected behavior when there are more than one policy template defined.
+	Owner                   Owner                      `json:"owner,omitempty" yaml:"owner,omitempty"`
+	Elasticsearch           *ElasticsearchRequirements `json:"elasticsearch,omitempty" yaml:"elasticsearch,omitempty"`
+	Agent                   *AgentRequirements         `json:"agent,omitempty" yaml:"agent,omitempty"`
+	DeploymentModes         *DeploymentModes           `json:"deployment_modes,omitempty" yaml:"deployment_modes,omitempty"`
+	Discovery               *Discovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
 
 	sourceFile string
 }


### PR DESCRIPTION
Support policy_templates_behavior found in package manifest.yml files.

Relates elastic/package-spec PR 825